### PR TITLE
Release/v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [0.2.0] - 2022-02-24
 ### Changed
+- Renamed `size.NewSize` to `size.New`.
 - Optimized `size.unmarshalJSONObject` implementation.
 
 ## [0.1.0] - 2022-02-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ## [0.2.0] - 2022-02-24
+### Added
+- Introduced new constants `size.ObjectKeyValue` and `size.ObjectKeyUnit`.
+
 ### Changed
 - Renamed `size.NewSize` to `size.New`.
 - Optimized `size.unmarshalJSONObject` implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Renamed `size.NewSize` to `size.New`.
 - Optimized `size.unmarshalJSONObject` implementation.
 
+### Removed
+- Variable `sem.Zero`.
+  - Use `sem.Ver{}` instead.
+
 ## [0.1.0] - 2022-02-22
 ### Added
 - First release of util.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Removed
 - Variable `sem.Zero`.
   - Use `sem.Ver{}` instead.
+- Name of `date.filterNo.Contains` receiver.
 
 ## [0.1.0] - 2022-02-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [0.2.0] - 2022-02-24
 ### Added
 - Introduced new constants `size.ObjectKeyValue` and `size.ObjectKeyUnit`.
+- Missing doc comments.
 
 ### Changed
 - Renamed `size.NewSize` to `size.New`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-02-24
+### Changed
+- Optimized `size.unmarshalJSONObject` implementation.
+
 ## [0.1.0] - 2022-02-22
 ### Added
 - First release of util.
 
-[Unreleased]: https://github.com/livesport-tv/util/compare/v0.1.0...master
+[Unreleased]: https://github.com/livesport-tv/util/compare/v0.2.0...master
+[0.2.0]: https://github.com/livesport-tv/util/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/livesport-tv/util/releases/tag/v0.1.0

--- a/date/filter.go
+++ b/date/filter.go
@@ -48,7 +48,7 @@ func FilterFromTo(from, to *Date) (Filter, error) {
 type filterNo struct {
 }
 
-func (_ filterNo) Contains(_ Date) bool {
+func (filterNo) Contains(_ Date) bool {
 	return true
 }
 

--- a/internal/helper.go
+++ b/internal/helper.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 )
 
+// Bprintf formats according to a format specifier and append it to passed buffer.
+// It returns passed buffer with added text.
 func Bprintf(buf []byte, format string, a ...interface{}) []byte {
 	b := bytes.NewBuffer(buf)
 	// fmt.Fprintf calls b.Write, which never returns error

--- a/sem/const.go
+++ b/sem/const.go
@@ -11,8 +11,3 @@ const (
 	// ZeroStringTag represents zero version in string tag form.
 	ZeroStringTag = "v0.0.0"
 )
-
-var (
-	// Zero represents zero version value.
-	Zero = Ver{}
-)

--- a/size/errors.go
+++ b/size/errors.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 )
 
+// InvalidUnitError represents invalid unit.
+// Value of error is invalid unit itself.
 type InvalidUnitError string
 
 func newInvalidUnitError(unit string) *InvalidUnitError {
@@ -15,6 +17,7 @@ func newInvalidUnitError(unit string) *InvalidUnitError {
 	return &err
 }
 
+// Error returns string representation of error.
 func (e *InvalidUnitError) Error() string {
 	const message = "invalid unit"
 	if e == nil {
@@ -23,6 +26,7 @@ func (e *InvalidUnitError) Error() string {
 	return fmt.Sprintf("%s %q", message, string(*e))
 }
 
+// InvalidValueError represents invalid combination of value and unit.
 type InvalidValueError struct {
 	Value uint64
 	Unit  string
@@ -35,6 +39,7 @@ func newInvalidValueError(value uint64, unit string) *InvalidValueError {
 	}
 }
 
+// Error returns string representation of error.
 func (e *InvalidValueError) Error() string {
 	if e.Unit == "" {
 		return fmt.Sprintf("value %d without unit is not suitable for uint64", e.Value)
@@ -42,6 +47,8 @@ func (e *InvalidValueError) Error() string {
 	return fmt.Sprintf("value %d with unit %q is not suitable for uint64", e.Value, e.Unit)
 }
 
+// ParseError represents error during version parsing.
+// Input can be empty, as same as Err.
 type ParseError struct {
 	Func  string
 	Input string
@@ -56,10 +63,12 @@ func newParseError(funcName, input string, err error) *ParseError {
 	}
 }
 
+// Unwrap returns under-laying error if any.
 func (e *ParseError) Unwrap() error {
 	return e.Err
 }
 
+// Error returns string representation of error.
 func (e *ParseError) Error() string {
 	err := "unable to parse"
 	if e.Err != nil {

--- a/size/size.go
+++ b/size/size.go
@@ -256,9 +256,10 @@ func (s Size) String() string {
 
 func (s Size) marshalJSONObject() []byte {
 	value, unit := s.Shorten()
-	b := []byte(`{"value":`)
+	b := make([]byte, 0, 32)
+	b = append(b, `{"`+ObjectKeyValue+`":`...)
 	b = strconv.AppendUint(b, value, 10)
-	b = append(b, `,"unit":"`...)
+	b = append(b, `,"`+ObjectKeyUnit+`":"`...)
 	b = append(b, unit...)
 	b = append(b, `"}`...)
 	return b

--- a/size/size.go
+++ b/size/size.go
@@ -28,8 +28,8 @@ var (
 // If unit is not present, number is always represented as value in bytes.
 type Size uint64
 
-// NewSize creates new Size value with specified unit.
-func NewSize(value uint64, unit string) (Size, error) {
+// New creates new Size value with specified unit.
+func New(value uint64, unit string) (Size, error) {
 	if value == 0 {
 		if _, ok := zeroUnits[unit]; !ok {
 			return 0, newInvalidUnitError(unit)

--- a/size/size.go
+++ b/size/size.go
@@ -52,7 +52,7 @@ func New(value uint64, unit string) (Size, error) {
 
 // Shorten returns the biggest unit as is possible for value without rounding.
 // Returned unit is always valid and binary (1024^x).
-// Example: For Size(1024) is returned (1, "kB"), but for Size(1025) is returned (1025, "B").
+// Example: For Size(1024) is returned (1, "KiB"), but for Size(1025) is returned (1025, "B").
 func (s Size) Shorten() (value uint64, unit string) {
 	if s == 0 {
 		return 0, Byte
@@ -187,7 +187,7 @@ func (s *Size) UnmarshalText(data []byte) error {
 // Example of JSON object form for Size(1024):
 //   {
 //     "value": 1,
-//     "unit": "kB"
+//     "unit": "KiB"
 //   }
 //
 // See also DisableMarshalJSONObjectForm and DisableMarshalJSONStringForm.

--- a/size/size_test.go
+++ b/size/size_test.go
@@ -14,31 +14,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func assertNewSize(t *testing.T, expected Size, value uint64, unit string) {
+func assertNew(t *testing.T, expected Size, value uint64, unit string) {
 	t.Helper()
-	actual, err := NewSize(value, unit)
+	actual, err := New(value, unit)
 	assert.Equal(t, expected, actual)
 	assert.NoError(t, err)
 }
 
-func assertNewSizeFail(t *testing.T, error string, value uint64, unit string) {
+func assertNewFail(t *testing.T, error string, value uint64, unit string) {
 	t.Helper()
-	actual, err := NewSize(value, unit)
+	actual, err := New(value, unit)
 	assert.Zero(t, actual)
 	assert.EqualError(t, err, error)
 }
 
-func Test_NewSize(t *testing.T) {
-	assertNewSize(t, 0, 0, "")
-	assertNewSizeFail(t, `invalid unit "h"`, 0, "h")
-	assertNewSize(t, 1, 1, "")
-	assertNewSizeFail(t, `invalid unit "h"`, 1, "h")
-	assertNewSizeFail(t, `invalid unit "YB"`, 1, Yottabyte)
-	assertNewSizeFail(t, `invalid unit "YiB"`, 1, Yobibyte)
-	assertNewSizeFail(t, `invalid unit "ZB"`, 1, Zettabyte)
-	assertNewSizeFail(t, `invalid unit "ZiB"`, 1, Zebibyte)
-	assertNewSizeFail(t, `value 18446744073709551615 with unit "EiB" is not suitable for uint64`, math.MaxUint64, Exbibyte)
-	assertNewSize(t, 1024*1024, 1, Mebibyte)
+func Test_New(t *testing.T) {
+	assertNew(t, 0, 0, "")
+	assertNewFail(t, `invalid unit "h"`, 0, "h")
+	assertNew(t, 1, 1, "")
+	assertNewFail(t, `invalid unit "h"`, 1, "h")
+	assertNewFail(t, `invalid unit "YB"`, 1, Yottabyte)
+	assertNewFail(t, `invalid unit "YiB"`, 1, Yobibyte)
+	assertNewFail(t, `invalid unit "ZB"`, 1, Zettabyte)
+	assertNewFail(t, `invalid unit "ZiB"`, 1, Zebibyte)
+	assertNewFail(t, `value 18446744073709551615 with unit "EiB" is not suitable for uint64`, math.MaxUint64, Exbibyte)
+	assertNew(t, 1024*1024, 1, Mebibyte)
 }
 
 func Test_Size_Shorten(t *testing.T) {

--- a/size/unmarshal.go
+++ b/size/unmarshal.go
@@ -13,6 +13,11 @@ import (
 	"strings"
 )
 
+const (
+	ObjectKeyValue = "value"
+	ObjectKeyUnit  = "unit"
+)
+
 var (
 	// MaxTextLength allows limiting UnmarshalText input.
 	// Set 0 to disable this setting.
@@ -171,7 +176,7 @@ keys:
 		// string is guaranteed by encoding/json package
 		key := t.(string)
 		switch strings.ToLower(key) {
-		case "value":
+		case ObjectKeyValue:
 			if value != nil {
 				return 0, errors.New("duplicated value key")
 			}
@@ -182,7 +187,7 @@ keys:
 			if !d.More() {
 				break keys
 			}
-		case "unit":
+		case ObjectKeyUnit:
 			if unit != nil {
 				return 0, errors.New("duplicated unit key")
 			}

--- a/size/unmarshal.go
+++ b/size/unmarshal.go
@@ -73,7 +73,7 @@ func DefaultUnmarshalText(data []byte) (Size, error) {
 		return 0, newParseError(funcName, s, errors.New("unit disabled"))
 	}
 
-	size, err := NewSize(value, unit)
+	size, err := New(value, unit)
 	if err != nil {
 		return 0, newParseError(funcName, s, err)
 	}
@@ -209,7 +209,7 @@ func newOrError(value *uint64, unit *string) (Size, error) {
 	if unit == nil {
 		return 0, errors.New("missing unit key")
 	}
-	return NewSize(*value, *unit)
+	return New(*value, *unit)
 }
 
 func decodeValue(d decoder) (*uint64, error) {

--- a/size/unmarshal.go
+++ b/size/unmarshal.go
@@ -199,6 +199,10 @@ keys:
 			}
 		}
 	}
+	return newOrError(value, unit)
+}
+
+func newOrError(value *uint64, unit *string) (Size, error) {
 	if value == nil {
 		return 0, errors.New("missing value key")
 	}

--- a/size/unmarshal_test.go
+++ b/size/unmarshal_test.go
@@ -225,43 +225,43 @@ func Test_unmarshalJSONObject(t *testing.T) {
 	assert.Zero(t, s)
 	assert.EqualError(t, err, `no token`)
 
-	s, err = unmarshalJSONObject(newDecoderMock("value", 0))
+	s, err = unmarshalJSONObject(newDecoderMock(ObjectKeyValue, 0))
 	assert.Zero(t, s)
 	assert.EqualError(t, err, `expected type json.Number instead of int for value`)
 
-	s, err = unmarshalJSONObject(newDecoderMock("value", json.Number(`0`)))
+	s, err = unmarshalJSONObject(newDecoderMock(ObjectKeyValue, json.Number(`0`)))
 	assert.Zero(t, s)
 	assert.EqualError(t, err, `missing unit key`)
 
-	s, err = unmarshalJSONObject(newDecoderMock("value", json.Number(`0`), errNoToken))
+	s, err = unmarshalJSONObject(newDecoderMock(ObjectKeyValue, json.Number(`0`), errNoToken))
 	assert.Zero(t, s)
 	assert.EqualError(t, err, `no token`)
 
-	s, err = unmarshalJSONObject(newDecoderMock("value", json.Number(`0`), "value"))
+	s, err = unmarshalJSONObject(newDecoderMock(ObjectKeyValue, json.Number(`0`), ObjectKeyValue))
 	assert.Zero(t, s)
 	assert.EqualError(t, err, `duplicated value key`)
 
-	s, err = unmarshalJSONObject(newDecoderMock("value", json.Number(`0`), "unit", errNoToken))
+	s, err = unmarshalJSONObject(newDecoderMock(ObjectKeyValue, json.Number(`0`), ObjectKeyUnit, errNoToken))
 	assert.Zero(t, s)
 	assert.EqualError(t, err, `no token`)
 
-	s, err = unmarshalJSONObject(newDecoderMock("value", json.Number(`0`), "unit", 0))
+	s, err = unmarshalJSONObject(newDecoderMock(ObjectKeyValue, json.Number(`0`), ObjectKeyUnit, 0))
 	assert.Zero(t, s)
 	assert.EqualError(t, err, `expected type string instead of int for unit`)
 
-	s, err = unmarshalJSONObject(newDecoderMock("value", json.Number(`0`), "unit", `B`))
+	s, err = unmarshalJSONObject(newDecoderMock(ObjectKeyValue, json.Number(`0`), ObjectKeyUnit, `B`))
 	assert.Zero(t, s)
 	assert.NoError(t, err)
 
-	s, err = unmarshalJSONObject(newDecoderMock("unit", `B`))
+	s, err = unmarshalJSONObject(newDecoderMock(ObjectKeyUnit, `B`))
 	assert.Zero(t, s)
 	assert.EqualError(t, err, `missing value key`)
 
-	s, err = unmarshalJSONObject(newDecoderMock("unit", `B`, "unit"))
+	s, err = unmarshalJSONObject(newDecoderMock(ObjectKeyUnit, `B`, ObjectKeyUnit))
 	assert.Zero(t, s)
 	assert.EqualError(t, err, `duplicated unit key`)
 
-	s, err = unmarshalJSONObject(newDecoderMock("unit", `B`, "value", json.Number(`0`)))
+	s, err = unmarshalJSONObject(newDecoderMock(ObjectKeyUnit, `B`, ObjectKeyValue, json.Number(`0`)))
 	assert.Zero(t, s)
 	assert.NoError(t, err)
 

--- a/size/unmarshal_test.go
+++ b/size/unmarshal_test.go
@@ -271,6 +271,22 @@ func Test_unmarshalJSONObject(t *testing.T) {
 	assert.EqualError(t, err, `object too big (3 > 2)`)
 }
 
+func Test_newOrError(t *testing.T) {
+	s, err := newOrError(nil, nil)
+	assert.Zero(t, s)
+	assert.EqualError(t, err, `missing value key`)
+
+	value := uint64(5)
+	s, err = newOrError(&value, nil)
+	assert.Zero(t, s)
+	assert.EqualError(t, err, `missing unit key`)
+
+	unit := Kibibyte
+	s, err = newOrError(&value, &unit)
+	assert.Equal(t, Size(5*1024), s)
+	assert.NoError(t, err)
+}
+
 func Test_decodeValue(t *testing.T) {
 	s, err := decodeValue(newDecoderMock(errNoToken))
 	assert.Nil(t, s)


### PR DESCRIPTION
# Description
## [0.2.0] - 2022-02-24
### Added
- Introduced new constants `size.ObjectKeyValue` and `size.ObjectKeyUnit`.
- Missing doc comments.

### Changed
- Renamed `size.NewSize` to `size.New`.
- Optimized `size.unmarshalJSONObject` implementation.

### Removed
- Variable `sem.Zero`.
  - Use `sem.Ver{}` instead.
- Name of `date.filterNo.Contains` receiver.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Documentation update.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] `go test`
- [x] `go vet`

**Run Configuration**:
- `util` package version: `0.1.0`
- Go version: `go1.18beta2`
- Operating system: `darwin`
- Processor architecture: `amd64`

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] My change is documented in `CHANGELOG.md`.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (`README.md`, `openapi.yaml`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

@schenkova @bafrnec
