### PR TITLE
Release/v0.4.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
     types: [ published ]
 
 env:
-  GO_VERSION: 1.17
+  GO_VERSION: 1.18
 
 jobs:
   go-test:
@@ -22,6 +22,6 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     - name: go test
       run: |
-        go fmt ./... & \
-        go vet ./... & \
+        go fmt ./... && \
+        go vet ./... && \
         go test -v ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2022-03-01
+### Changed
+- Type `Rule` doc comments (all packages).
+
 ## [0.3.0] - 2022-02-28
 ### Added
 - Type `Rule` and `DefaultParser` parameter of same type (all packages).
@@ -44,7 +48,8 @@
 ### Added
 - First release of util.
 
-[Unreleased]: https://github.com/livesport-tv/util/compare/v0.3.0...master
+[Unreleased]: https://github.com/livesport-tv/util/compare/v0.4.0...master
+[0.4.0]: https://github.com/livesport-tv/util/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/livesport-tv/util/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/livesport-tv/util/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/livesport-tv/util/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 - Type `Rule` doc comments (all packages).
+- Used `any` instead of `interface{}`.
 - Generic support:
   - Error types.
   - Function `size.New`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,29 @@
 
 ## [0.4.0] - 2022-03-16
 ### Added
+- Package `constraint` with generic support and helpers.
+- Function `size.Bytes` with generic support.
 - Methods `sem.Ver.NextMajor`, `sem.Ver.NextMinor` and `sem.Ver.NextPatch`.
 
 ### Changed
 - Type `Rule` doc comments (all packages).
+- Generic support:
+  - Type `size.InvalidValueError`
+  - Function `size.New`
 - Updated:
   - Go to 1.18
   - `github.com/stretchr/testify` to `1.7.1`
+
+### Removed
+- Methods of `size.Size`:
+  - `BytesInt`
+  - `BytesUint`
+  - `BytesInt32`
+  - `BytesUint32`
+  - `BytesInt64`
+  - `BytesUint64`
+  - `BytesFloat32`
+  - `BytesFloat64`
 
 ## [0.3.0] - 2022-02-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ## [0.4.0] - 2022-03-01
+### Added
+- Methods `sem.Ver.NextMajor`, `sem.Ver.NextMinor` and `sem.Ver.NextPatch`.
+
 ### Changed
 - Type `Rule` doc comments (all packages).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 ### Changed
 - Type `Rule` doc comments (all packages).
 - Generic support:
-  - Type `size.InvalidValueError`
+  - Error types.
   - Function `size.New`
+  - All parser functions now accepts `constraint.ParserInput`.
 - Updated:
   - Go to 1.18
   - `github.com/stretchr/testify` to `1.7.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## [Unreleased]
 
-## [0.4.0] - 2022-03-01
+## [0.4.0] - 2022-03-16
 ### Added
 - Methods `sem.Ver.NextMajor`, `sem.Ver.NextMinor` and `sem.Ver.NextPatch`.
 
 ### Changed
 - Type `Rule` doc comments (all packages).
+- Updated:
+  - Go to 1.18
+  - `github.com/stretchr/testify` to `1.7.1`
 
 ## [0.3.0] - 2022-02-28
 ### Added

--- a/constraint/constraint.go
+++ b/constraint/constraint.go
@@ -1,0 +1,6 @@
+// Copyright 2022 Livesport TV s.r.o. All rights reserved.
+// Use of this source code is governed by a MIT license
+// that can be found in the LICENSE file.
+
+// Package constraint contains generic support and helper functions.
+package constraint

--- a/constraint/funcs.go
+++ b/constraint/funcs.go
@@ -1,0 +1,49 @@
+// Copyright 2022 Livesport TV s.r.o. All rights reserved.
+// Use of this source code is governed by a MIT license
+// that can be found in the LICENSE file.
+
+package constraint
+
+import (
+	"unsafe"
+
+	"go.lstv.dev/util/internal"
+)
+
+// IsFloat returns true if type is float* type.
+func IsFloat[N Numbers]() bool {
+	return internal.IsFloat(internal.Kind(N(0)))
+}
+
+// IsSigned returns true if type is signed integer type or float* type.
+func IsSigned[N Numbers]() bool {
+	return internal.IsSigned(internal.Kind(N(0)))
+}
+
+// SmallestNonzero returns the smallest non-zero value of specified type.
+// For integer types returns 1, for float types theirs the smallest non-zero values.
+// It always returns positive numbers, so for unsigned integer types, value 1 is returned.
+func SmallestNonzero[N Numbers]() N {
+	return internal.SmallestNonzero[N](internal.Kind(N(0)))
+}
+
+// Min returns the minimum value of specified type.
+// For unsigned integer types returns 0, for signed integer types and float types theirs the minimum negative value.
+func Min[N Numbers]() N {
+	return internal.Min[N](internal.Kind(N(0)))
+}
+
+// Max returns the maximum value of specified type.
+func Max[N Numbers]() N {
+	return internal.Max[N](internal.Kind(N(0)))
+}
+
+// SizeBytes returns size in bytes of specified type.
+func SizeBytes[N Numbers]() int {
+	return int(unsafe.Sizeof(N(0)))
+}
+
+// SizeBits returns size in bits of specified type.
+func SizeBits[N Numbers]() int {
+	return SizeBytes[N]() * 8
+}

--- a/constraint/funcs_test.go
+++ b/constraint/funcs_test.go
@@ -1,0 +1,125 @@
+// Copyright 2022 Livesport TV s.r.o. All rights reserved.
+// Use of this source code is governed by a MIT license
+// that can be found in the LICENSE file.
+
+package constraint
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_IsFloat(t *testing.T) {
+	assert.False(t, IsFloat[int]())
+	assert.False(t, IsFloat[int8]())
+	assert.False(t, IsFloat[int16]())
+	assert.False(t, IsFloat[int32]())
+	assert.False(t, IsFloat[int64]())
+	assert.False(t, IsFloat[uint]())
+	assert.False(t, IsFloat[uint8]())
+	assert.False(t, IsFloat[uint16]())
+	assert.False(t, IsFloat[uint32]())
+	assert.False(t, IsFloat[uint64]())
+	assert.True(t, IsFloat[float32]())
+	assert.True(t, IsFloat[float64]())
+}
+
+func Test_IsSigned(t *testing.T) {
+	assert.True(t, IsSigned[int]())
+	assert.True(t, IsSigned[int8]())
+	assert.True(t, IsSigned[int16]())
+	assert.True(t, IsSigned[int32]())
+	assert.True(t, IsSigned[int64]())
+	assert.False(t, IsSigned[uint]())
+	assert.False(t, IsSigned[uint8]())
+	assert.False(t, IsSigned[uint16]())
+	assert.False(t, IsSigned[uint32]())
+	assert.False(t, IsSigned[uint64]())
+	assert.True(t, IsSigned[float32]())
+	assert.True(t, IsSigned[float64]())
+}
+
+func Test_SmallestNonzero(t *testing.T) {
+	assert.Equal(t, int(1), SmallestNonzero[int]())
+	assert.Equal(t, int8(1), SmallestNonzero[int8]())
+	assert.Equal(t, int16(1), SmallestNonzero[int16]())
+	assert.Equal(t, int32(1), SmallestNonzero[int32]())
+	assert.Equal(t, int64(1), SmallestNonzero[int64]())
+	assert.Equal(t, uint(1), SmallestNonzero[uint]())
+	assert.Equal(t, uint8(1), SmallestNonzero[uint8]())
+	assert.Equal(t, uint16(1), SmallestNonzero[uint16]())
+	assert.Equal(t, uint32(1), SmallestNonzero[uint32]())
+	assert.Equal(t, uint64(1), SmallestNonzero[uint64]())
+	assert.Equal(t, float32(math.SmallestNonzeroFloat32), SmallestNonzero[float32]())
+	assert.Equal(t, float64(math.SmallestNonzeroFloat64), SmallestNonzero[float64]())
+}
+
+func Test_Min(t *testing.T) {
+	assert.Equal(t, int(math.MinInt), Min[int]())
+	assert.Equal(t, int8(math.MinInt8), Min[int8]())
+	assert.Equal(t, int16(math.MinInt16), Min[int16]())
+	assert.Equal(t, int32(math.MinInt32), Min[int32]())
+	assert.Equal(t, int64(math.MinInt64), Min[int64]())
+	assert.Equal(t, uint(0), Min[uint]())
+	assert.Equal(t, uint8(0), Min[uint8]())
+	assert.Equal(t, uint16(0), Min[uint16]())
+	assert.Equal(t, uint32(0), Min[uint32]())
+	assert.Equal(t, uint64(0), Min[uint64]())
+	assert.Equal(t, float32(-math.MaxFloat32), Min[float32]())
+	assert.Equal(t, float64(-math.MaxFloat64), Min[float64]())
+}
+
+func Test_Max(t *testing.T) {
+	assert.Equal(t, int(math.MaxInt), Max[int]())
+	assert.Equal(t, int8(math.MaxInt8), Max[int8]())
+	assert.Equal(t, int16(math.MaxInt16), Max[int16]())
+	assert.Equal(t, int32(math.MaxInt32), Max[int32]())
+	assert.Equal(t, int64(math.MaxInt64), Max[int64]())
+	assert.Equal(t, uint(math.MaxUint), Max[uint]())
+	assert.Equal(t, uint8(math.MaxUint8), Max[uint8]())
+	assert.Equal(t, uint16(math.MaxUint16), Max[uint16]())
+	assert.Equal(t, uint32(math.MaxUint32), Max[uint32]())
+	assert.Equal(t, uint64(math.MaxUint64), Max[uint64]())
+	assert.Equal(t, float32(math.MaxFloat32), Max[float32]())
+	assert.Equal(t, float64(math.MaxFloat64), Max[float64]())
+}
+
+func Test_SizeBytes(t *testing.T) {
+	intSizeBytes := 8
+	if math.MaxInt == math.MaxInt32 {
+		intSizeBytes = 4
+	}
+	assert.Equal(t, intSizeBytes, SizeBytes[int]())
+	assert.Equal(t, 1, SizeBytes[int8]())
+	assert.Equal(t, 2, SizeBytes[int16]())
+	assert.Equal(t, 4, SizeBytes[int32]())
+	assert.Equal(t, 8, SizeBytes[int64]())
+	assert.Equal(t, intSizeBytes, SizeBytes[uint]())
+	assert.Equal(t, 1, SizeBytes[uint8]())
+	assert.Equal(t, 2, SizeBytes[uint16]())
+	assert.Equal(t, 4, SizeBytes[uint32]())
+	assert.Equal(t, 8, SizeBytes[uint64]())
+	assert.Equal(t, 4, SizeBytes[float32]())
+	assert.Equal(t, 8, SizeBytes[float64]())
+}
+
+func Test_SizeBits(t *testing.T) {
+	intSizeBits := 64
+	if math.MaxInt == math.MaxInt32 {
+		intSizeBits = 32
+	}
+	assert.Equal(t, intSizeBits, SizeBits[int]())
+	assert.Equal(t, 8, SizeBits[int8]())
+	assert.Equal(t, 16, SizeBits[int16]())
+	assert.Equal(t, 32, SizeBits[int32]())
+	assert.Equal(t, 64, SizeBits[int64]())
+	assert.Equal(t, intSizeBits, SizeBits[uint]())
+	assert.Equal(t, 8, SizeBits[uint8]())
+	assert.Equal(t, 16, SizeBits[uint16]())
+	assert.Equal(t, 32, SizeBits[uint32]())
+	assert.Equal(t, 64, SizeBits[uint64]())
+	assert.Equal(t, 32, SizeBits[float32]())
+	assert.Equal(t, 64, SizeBits[float64]())
+}

--- a/constraint/types.go
+++ b/constraint/types.go
@@ -1,0 +1,27 @@
+// Copyright 2022 Livesport TV s.r.o. All rights reserved.
+// Use of this source code is governed by a MIT license
+// that can be found in the LICENSE file.
+
+package constraint
+
+// Ints represents all int* types and their derived types.
+type Ints interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// Uints represents all uint* types and their derived types.
+// Type uintptr is not part of Uints because package aims to numbers with specified value.
+type Uints interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+// Floats represents all float* types and their derived types.
+type Floats interface {
+	~float32 | ~float64
+}
+
+// Numbers represents all number types and their derived types.
+// See also Ints, Uints and Floats.
+type Numbers interface {
+	Ints | Uints | Floats
+}

--- a/constraint/types.go
+++ b/constraint/types.go
@@ -4,6 +4,11 @@
 
 package constraint
 
+// ParserInput represents parser input.
+type ParserInput interface {
+	~[]byte | ~string
+}
+
 // Ints represents all int* types and their derived types.
 type Ints interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64

--- a/date/date.go
+++ b/date/date.go
@@ -217,7 +217,7 @@ func (d *Date) UnmarshalText(data []byte) error {
 
 // Scan is support for database/sql package.
 // It can return wrapped ErrInvalidType.
-func (d *Date) Scan(src interface{}) error {
+func (d *Date) Scan(src any) error {
 	if t, ok := src.(time.Time); ok {
 		d.FromTime(t)
 		return nil

--- a/date/errors.go
+++ b/date/errors.go
@@ -7,6 +7,8 @@ package date
 import (
 	"errors"
 	"fmt"
+
+	"go.lstv.dev/util/constraint"
 )
 
 var (
@@ -37,14 +39,14 @@ var (
 
 // ParseError represents error during date parsing.
 // Input can be empty, as same as Err.
-type ParseError struct {
+type ParseError[T constraint.ParserInput] struct {
 	Func  string
-	Input string
+	Input T
 	Err   error
 }
 
-func newParseError(funcName, input string, err error) *ParseError {
-	return &ParseError{
+func newParseError[T constraint.ParserInput](funcName string, input T, err error) *ParseError[T] {
+	return &ParseError[T]{
 		Func:  funcName,
 		Input: input,
 		Err:   err,
@@ -52,17 +54,17 @@ func newParseError(funcName, input string, err error) *ParseError {
 }
 
 // Unwrap returns under-laying error if any.
-func (e *ParseError) Unwrap() error {
+func (e *ParseError[T]) Unwrap() error {
 	return e.Err
 }
 
 // Error returns string representation of error.
-func (e *ParseError) Error() string {
+func (e *ParseError[T]) Error() string {
 	err := "invalid date"
 	if e.Err != nil {
 		err = e.Err.Error()
 	}
-	if e.Input == "" {
+	if len(e.Input) == 0 {
 		return fmt.Sprintf("date.%s: %s", e.Func, err)
 	}
 	return fmt.Sprintf("date.%s: %q: %s", e.Func, e.Input, err)

--- a/date/errors_test.go
+++ b/date/errors_test.go
@@ -13,7 +13,7 @@ import (
 
 func Test_newParseError(t *testing.T) {
 	err := errors.New("parse error")
-	assert.Equal(t, &ParseError{
+	assert.Equal(t, &ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   err,
@@ -22,7 +22,7 @@ func Test_newParseError(t *testing.T) {
 
 func Test_ParseError_Unwrap(t *testing.T) {
 	err := errors.New("parse error")
-	assert.Equal(t, err, (&ParseError{
+	assert.Equal(t, err, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   err,
@@ -31,22 +31,22 @@ func Test_ParseError_Unwrap(t *testing.T) {
 
 func Test_ParseError_Error(t *testing.T) {
 	err := errors.New("parse error")
-	assert.Equal(t, `date.UnmarshalJSON: invalid date`, (&ParseError{
+	assert.Equal(t, `date.UnmarshalJSON: invalid date`, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "",
 		Err:   nil,
 	}).Error())
-	assert.Equal(t, `date.UnmarshalJSON: parse error`, (&ParseError{
+	assert.Equal(t, `date.UnmarshalJSON: parse error`, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "",
 		Err:   err,
 	}).Error())
-	assert.Equal(t, `date.UnmarshalJSON: "1h": invalid date`, (&ParseError{
+	assert.Equal(t, `date.UnmarshalJSON: "1h": invalid date`, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   nil,
 	}).Error())
-	assert.Equal(t, `date.UnmarshalJSON: "1h": parse error`, (&ParseError{
+	assert.Equal(t, `date.UnmarshalJSON: "1h": parse error`, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   err,

--- a/date/parse.go
+++ b/date/parse.go
@@ -25,6 +25,8 @@ var (
 
 type (
 	// Rule allows configuring Parser behavior.
+	// Available rules are:
+	//   RuleDisableBasic
 	Rule int
 )
 

--- a/date/parse.go
+++ b/date/parse.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+
+	"go.lstv.dev/util/constraint"
 )
 
 var (
@@ -18,7 +20,7 @@ var (
 	MaxInputLength = 10
 
 	// Parser is used by Date.UnmarshalText function.
-	Parser = DefaultParser
+	Parser = DefaultParser[[]byte]
 
 	pattern = regexp.MustCompile(`^([0-9]{4,9})-?(1[0-2]|0[0-9])-?(3[01]|[0-2][0-9])$`)
 )
@@ -38,26 +40,28 @@ const (
 // DefaultParser parse Date from input.
 //
 // See also MaxInputLength.
-func DefaultParser(input []byte, r Rule) (date Date, err error) {
+func DefaultParser[T constraint.ParserInput](input T, r Rule) (date Date, err error) {
 	const funcName = "DefaultParser"
-	l := len(input)
+	b := []byte(input)
+	l := len(b)
 	if l == 0 {
-		return Date{}, newParseError(funcName, "", nil)
+		return Date{}, newParseError(funcName, b, nil)
 	}
 	if MaxInputLength != 0 && l > MaxInputLength {
 		// do not use input for "input too long" error
-		return Date{}, newParseError(funcName, "", fmt.Errorf("%w: %d > %d", ErrInputTooLong, l, MaxInputLength))
+		var t T
+		return Date{}, newParseError(funcName, t, fmt.Errorf("%w: %d > %d", ErrInputTooLong, l, MaxInputLength))
 	}
-	parts := pattern.FindSubmatch(input)
+	parts := pattern.FindSubmatch(b)
 	if len(parts) == 0 {
-		return Date{}, newParseError(funcName, string(input), nil)
+		return Date{}, newParseError(funcName, input, nil)
 	}
-	if sep2 := input[l-3] == '-'; sep2 || input[l-5] == '-' { // extended format
-		if !sep2 || input[l-6] != '-' { // disallow YYYY-MMDD and YYYYMM-YY formats
-			return Date{}, newParseError(funcName, string(input), nil)
+	if sep2 := b[l-3] == '-'; sep2 || b[l-5] == '-' { // extended format
+		if !sep2 || b[l-6] != '-' { // disallow YYYY-MMDD and YYYYMM-YY formats
+			return Date{}, newParseError(funcName, input, nil)
 		}
 	} else if r&RuleDisableBasic != 0 {
-		return Date{}, newParseError(funcName, string(input), ErrBasicFormatDisabled)
+		return Date{}, newParseError(funcName, input, ErrBasicFormatDisabled)
 	}
 	year, _ := strconv.Atoi(string(parts[1]))
 	month, _ := strconv.Atoi(string(parts[2]))

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module go.lstv.dev/util
 
-go 1.17
+go 1.18
 
-require github.com/stretchr/testify v1.7.0
+require github.com/stretchr/testify v1.7.1
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/internal/constraint.go
+++ b/internal/constraint.go
@@ -1,0 +1,111 @@
+// Copyright 2022 Livesport TV s.r.o. All rights reserved.
+// Use of this source code is governed by a MIT license
+// that can be found in the LICENSE file.
+
+package internal
+
+import (
+	"math"
+	"reflect"
+)
+
+type ints interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+type uints interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+type floats interface {
+	~float32 | ~float64
+}
+
+type numbers interface {
+	ints | uints | floats
+}
+
+func Kind(value any) reflect.Kind {
+	return reflect.TypeOf(value).Kind()
+}
+
+func IsFloat(k reflect.Kind) bool {
+	switch k {
+	case reflect.Float32, reflect.Float64:
+		return true
+	default: // reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64
+		return false
+	}
+}
+
+func IsSigned(k reflect.Kind) bool {
+	switch k {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Float32, reflect.Float64:
+		return true
+	default: // reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64
+		return false
+	}
+}
+
+func SmallestNonzero[N numbers](k reflect.Kind) N {
+	switch k {
+	case reflect.Float32:
+		return N(any(float32(math.SmallestNonzeroFloat32)).(float32))
+	case reflect.Float64:
+		return N(any(float64(math.SmallestNonzeroFloat64)).(float64))
+	default: // reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64
+		return 1
+	}
+}
+
+func Min[N numbers](k reflect.Kind) N {
+	switch k {
+	case reflect.Int:
+		return N(any(int(math.MinInt)).(int))
+	case reflect.Int8:
+		return N(any(int8(math.MinInt8)).(int8))
+	case reflect.Int16:
+		return N(any(int16(math.MinInt16)).(int16))
+	case reflect.Int32:
+		return N(any(int32(math.MinInt32)).(int32))
+	case reflect.Int64:
+		return N(any(int64(math.MinInt64)).(int64))
+	case reflect.Float32:
+		return N(any(float32(-math.MaxFloat32)).(float32))
+	case reflect.Float64:
+		return N(any(float64(-math.MaxFloat64)).(float64))
+	default: // reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64
+		return 0
+	}
+}
+
+func Max[N numbers](k reflect.Kind) N {
+	switch k {
+	case reflect.Int:
+		return N(any(int(math.MaxInt)).(int))
+	case reflect.Int8:
+		return N(any(int8(math.MaxInt8)).(int8))
+	case reflect.Int16:
+		return N(any(int16(math.MaxInt16)).(int16))
+	case reflect.Int32:
+		return N(any(int32(math.MaxInt32)).(int32))
+	case reflect.Int64:
+		return N(any(int64(math.MaxInt64)).(int64))
+	case reflect.Uint:
+		return N(any(uint(math.MaxUint)).(uint))
+	case reflect.Uint8:
+		return N(any(uint8(math.MaxUint8)).(uint8))
+	case reflect.Uint16:
+		return N(any(uint16(math.MaxUint16)).(uint16))
+	case reflect.Uint32:
+		return N(any(uint32(math.MaxUint32)).(uint32))
+	case reflect.Uint64:
+		return N(any(uint64(math.MaxUint64)).(uint64))
+	case reflect.Float32:
+		return N(any(float32(math.MaxFloat32)).(float32))
+	case reflect.Float64:
+		return N(any(float64(math.MaxFloat64)).(float64))
+	default: // unreachable
+		return 0
+	}
+}

--- a/internal/constraint_test.go
+++ b/internal/constraint_test.go
@@ -1,0 +1,15 @@
+// Copyright 2022 Livesport TV s.r.o. All rights reserved.
+// Use of this source code is governed by a MIT license
+// that can be found in the LICENSE file.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Max_unreachable(t *testing.T) {
+	assert.Equal(t, int(0), Max[int](Kind("")))
+}

--- a/internal/helper.go
+++ b/internal/helper.go
@@ -11,7 +11,7 @@ import (
 
 // Bprintf formats according to a format specifier and append it to passed buffer.
 // It returns passed buffer with added text.
-func Bprintf(buf []byte, format string, a ...interface{}) []byte {
+func Bprintf(buf []byte, format string, a ...any) []byte {
 	b := bytes.NewBuffer(buf)
 	// fmt.Fprintf calls b.Write, which never returns error
 	fmt.Fprintf(b, format, a...)

--- a/roman/errors.go
+++ b/roman/errors.go
@@ -7,6 +7,8 @@ package roman
 import (
 	"errors"
 	"fmt"
+
+	"go.lstv.dev/util/constraint"
 )
 
 var (
@@ -17,14 +19,14 @@ var (
 
 // NumberFormatError represents error during number parsing.
 // Input can be empty, as same as Err.
-type NumberFormatError struct {
+type NumberFormatError[T constraint.ParserInput] struct {
 	Func  string
-	Input string
+	Input T
 	Err   error
 }
 
-func newNumberFormatError(funcName, input string, err error) *NumberFormatError {
-	return &NumberFormatError{
+func newNumberFormatError[T constraint.ParserInput](funcName string, input T, err error) *NumberFormatError[T] {
+	return &NumberFormatError[T]{
 		Func:  funcName,
 		Input: input,
 		Err:   err,
@@ -32,17 +34,17 @@ func newNumberFormatError(funcName, input string, err error) *NumberFormatError 
 }
 
 // Unwrap returns under-laying error if any.
-func (e *NumberFormatError) Unwrap() error {
+func (e *NumberFormatError[T]) Unwrap() error {
 	return e.Err
 }
 
 // Error returns string representation of error.
-func (e *NumberFormatError) Error() string {
+func (e *NumberFormatError[T]) Error() string {
 	err := "invalid roman number"
 	if e.Err != nil {
 		err = e.Err.Error()
 	}
-	if e.Input == "" {
+	if len(e.Input) == 0 {
 		return fmt.Sprintf("roman.%s: %s", e.Func, err)
 	}
 	return fmt.Sprintf("roman.%s: %q: %s", e.Func, e.Input, err)

--- a/roman/errors_test.go
+++ b/roman/errors_test.go
@@ -13,7 +13,7 @@ import (
 
 func Test_newNumberFormatError(t *testing.T) {
 	err := errors.New("parse error")
-	assert.Equal(t, &NumberFormatError{
+	assert.Equal(t, &NumberFormatError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   err,
@@ -22,7 +22,7 @@ func Test_newNumberFormatError(t *testing.T) {
 
 func Test_NumberFormatError_Unwrap(t *testing.T) {
 	err := errors.New("parse error")
-	assert.Equal(t, err, (&NumberFormatError{
+	assert.Equal(t, err, (&NumberFormatError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   err,
@@ -31,22 +31,22 @@ func Test_NumberFormatError_Unwrap(t *testing.T) {
 
 func Test_NumberFormatError_Error(t *testing.T) {
 	err := errors.New("parse error")
-	assert.Equal(t, `roman.UnmarshalJSON: invalid roman number`, (&NumberFormatError{
+	assert.Equal(t, `roman.UnmarshalJSON: invalid roman number`, (&NumberFormatError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "",
 		Err:   nil,
 	}).Error())
-	assert.Equal(t, `roman.UnmarshalJSON: parse error`, (&NumberFormatError{
+	assert.Equal(t, `roman.UnmarshalJSON: parse error`, (&NumberFormatError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "",
 		Err:   err,
 	}).Error())
-	assert.Equal(t, `roman.UnmarshalJSON: "1h": invalid roman number`, (&NumberFormatError{
+	assert.Equal(t, `roman.UnmarshalJSON: "1h": invalid roman number`, (&NumberFormatError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   nil,
 	}).Error())
-	assert.Equal(t, `roman.UnmarshalJSON: "1h": parse error`, (&NumberFormatError{
+	assert.Equal(t, `roman.UnmarshalJSON: "1h": parse error`, (&NumberFormatError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   err,

--- a/roman/parse.go
+++ b/roman/parse.go
@@ -20,6 +20,8 @@ var (
 
 type (
 	// Rule allows configuring Parser behavior.
+	// Available rules are:
+	//   RuleDisableEmptyAsZero
 	Rule int
 )
 

--- a/roman/parse.go
+++ b/roman/parse.go
@@ -6,6 +6,8 @@ package roman
 
 import (
 	"fmt"
+
+	"go.lstv.dev/util/constraint"
 )
 
 var (
@@ -15,7 +17,7 @@ var (
 	MaxInputLength = 128
 
 	// Parser is used by Number.UnmarshalText function.
-	Parser = DefaultParser
+	Parser = DefaultParser[[]byte]
 )
 
 type (
@@ -36,7 +38,7 @@ const (
 // Long and short forms of roman numbers are accepted (e.g. IIII and IV).
 //
 // See also MaxInputLength.
-func DefaultParser(input []byte, r Rule) (Number, error) {
+func DefaultParser[T constraint.ParserInput](input T, r Rule) (Number, error) {
 	const funcName = "DefaultParser"
 	empty, err := checkInputLength(funcName, input, r)
 	if err != nil {
@@ -45,9 +47,10 @@ func DefaultParser(input []byte, r Rule) (Number, error) {
 	if empty {
 		return 0, nil
 	}
-	p := pattern.FindSubmatch(input)
+	b := []byte(input)
+	p := pattern.FindSubmatch(b)
 	if len(p) == 0 {
-		return 0, newNumberFormatError(funcName, string(input), nil)
+		return 0, newNumberFormatError(funcName, input, nil)
 	}
 	decimal := uint64(len(p[1])) * 1000
 	for i, g := range groups {
@@ -77,7 +80,7 @@ func parseGroup(input []byte, unit uint64, digit5, digit10 byte) (decimal uint64
 	return l * unit
 }
 
-func checkInputLength(funcName string, input []byte, r Rule) (empty bool, err error) {
+func checkInputLength[T constraint.ParserInput](funcName string, input T, r Rule) (empty bool, err error) {
 	l := len(input)
 	if l == 0 {
 		if r&RuleDisableEmptyAsZero != 0 {

--- a/roman/parse_test.go
+++ b/roman/parse_test.go
@@ -79,14 +79,14 @@ func Test_DefaultParser(t *testing.T) {
 		// test in, "M"+in, "MM"+in...
 		for i := Number(0); i < 4; i++ {
 			expected := out + (1000 * i)
-			actual, err := DefaultParser([]byte(actualIn), 0)
+			actual, err := DefaultParser(actualIn, 0)
 			assert.NoError(t, err)
 			assert.Equalf(t, expected, actual, "%s should be %d, not %d", actualIn, expected, actual)
 			actualIn = string(thousand) + actualIn
 		}
 	}
 	for _, in := range invalid {
-		i, err := DefaultParser([]byte(in), 0)
+		i, err := DefaultParser(in, 0)
 		assert.Error(t, err)
 		assert.Zero(t, i)
 	}

--- a/roman/valid.go
+++ b/roman/valid.go
@@ -4,11 +4,15 @@
 
 package roman
 
+import (
+	"go.lstv.dev/util/constraint"
+)
+
 // Valid checks if passed value is valid roman number.
 // If not, error is returned.
 //
 // See also MaxInputLength.
-func Valid(input []byte, r Rule) error {
+func Valid[T constraint.ParserInput](input T, r Rule) error {
 	const funcName = "Valid"
 	empty, err := checkInputLength(funcName, input, r)
 	if err != nil {
@@ -17,8 +21,8 @@ func Valid(input []byte, r Rule) error {
 	if empty {
 		return nil
 	}
-	if !pattern.Match(input) {
-		return newNumberFormatError(funcName, string(input), nil)
+	if !pattern.Match([]byte(input)) {
+		return newNumberFormatError(funcName, input, nil)
 	}
 	return nil
 }

--- a/sem/compare.go
+++ b/sem/compare.go
@@ -6,44 +6,48 @@ package sem
 
 import (
 	"strings"
+
+	"go.lstv.dev/util/constraint"
 )
 
 var (
 	// ComparePreRelease is used as part of Ver.Compare.
 	// If major, minor and patch of compared versions are the same, ComparePreRelease is used.
-	ComparePreRelease = DefaultComparePreRelease
+	ComparePreRelease = DefaultComparePreRelease[string, string]
 )
 
 // DefaultComparePreRelease implements https://semver.org/#spec-item-11 rules.
-func DefaultComparePreRelease(a, b string) int {
-	if a == "" {
-		if b == "" {
+func DefaultComparePreRelease[T1, T2 constraint.ParserInput](a T1, b T2) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		if lb == 0 {
 			return 0
 		}
 		return 1
-	} else if b == "" {
+	} else if lb == 0 {
 		return -1
 	}
-	if len(a) > len(b) {
+	if la > lb {
 		return comparePreRelease(b, a)
 	}
 	return -comparePreRelease(a, b)
 }
 
-func comparePreRelease(shorter, longer string) int {
-	longerRunes := []rune(longer)
-	for i, sr := range shorter {
+func comparePreRelease[T1, T2 constraint.ParserInput](shorter T1, longer T2) int {
+	s, l := string(shorter), string(longer)
+	longerRunes := []rune(l)
+	for i, sr := range s {
 		if lr := longerRunes[i]; sr != lr {
-			return comparePreReleaseSuffix(shorter[i:], longer[i:])
+			return comparePreReleaseSuffix(s[i:], l[i:])
 		}
 	}
-	if len(shorter) == len(longer) {
+	if len(s) == len(l) {
 		return 0
 	}
 	return 1
 }
 
-func comparePreReleaseSuffix(shorter, longer string) int {
+func comparePreReleaseSuffix(shorter string, longer string) int {
 	if digitsOrEmpty.MatchString(shorter) && digitsOrEmpty.MatchString(longer) {
 		shorter = strings.TrimLeft(shorter, "0")
 		longer = strings.TrimLeft(longer, "0")
@@ -53,12 +57,12 @@ func comparePreReleaseSuffix(shorter, longer string) int {
 
 // CompareVersion compares passed versions.
 // Error is returned if passed versions are not valid.
-func CompareVersion(a, b string) (int, error) {
-	av, err := ParseVersion([]byte(a))
+func CompareVersion[T1, T2 constraint.ParserInput](a, b string) (int, error) {
+	av, err := ParseVersion(a)
 	if err != nil {
 		return 0, err
 	}
-	bv, err := ParseVersion([]byte(b))
+	bv, err := ParseVersion(b)
 	if err != nil {
 		return 0, err
 	}
@@ -67,12 +71,12 @@ func CompareVersion(a, b string) (int, error) {
 
 // CompareTag compares passed tag versions.
 // Error is returned if passed tag versions are not valid.
-func CompareTag(a, b string) (int, error) {
-	av, err := ParseTag([]byte(a))
+func CompareTag[T1, T2 constraint.ParserInput](a T1, b T2) (int, error) {
+	av, err := ParseTag(a)
 	if err != nil {
 		return 0, err
 	}
-	bv, err := ParseTag([]byte(b))
+	bv, err := ParseTag(b)
 	if err != nil {
 		return 0, err
 	}
@@ -81,12 +85,12 @@ func CompareTag(a, b string) (int, error) {
 
 // Compare compares passed tag versions or versions.
 // Error is returned if passed tag versions or versions are not valid.
-func Compare(a, b string) (int, error) {
-	av, err := Parse([]byte(a))
+func Compare[T1, T2 constraint.ParserInput](a T1, b T2) (int, error) {
+	av, err := Parse(a)
 	if err != nil {
 		return 0, err
 	}
-	bv, err := Parse([]byte(b))
+	bv, err := Parse(b)
 	if err != nil {
 		return 0, err
 	}

--- a/sem/compare_test.go
+++ b/sem/compare_test.go
@@ -7,6 +7,8 @@ package sem
 import (
 	"testing"
 
+	"go.lstv.dev/util/constraint"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,67 +36,67 @@ func Test_DefaultComparePreRelease(t *testing.T) {
 }
 
 func Test_CompareVersion(t *testing.T) {
-	testCompareVersion(t, CompareVersion)
+	testCompareVersion[string, string](t, CompareVersion[string, string])
 }
 
-func testCompareVersion(t *testing.T, f func(string, string) (int, error)) {
+func testCompareVersion[T1, T2 constraint.ParserInput](t *testing.T, f func(T1, T2) (int, error)) {
 	t.Helper()
-	c, err := f("0.0.0", "0.0.0")
+	c, err := f(T1("0.0.0"), T2("0.0.0"))
 	assert.Equal(t, 0, c)
 	assert.NoError(t, err)
-	c, err = f("1.0.0", "0.0.0")
+	c, err = f(T1("1.0.0"), T2("0.0.0"))
 	assert.Equal(t, 1, c)
 	assert.NoError(t, err)
-	c, err = f("0.0.0", "1.0.0")
+	c, err = f(T1("0.0.0"), T2("1.0.0"))
 	assert.Equal(t, -1, c)
 	assert.NoError(t, err)
-	c, err = f("1.0.0-alfa.1", "1.0.0-alfa.1")
+	c, err = f(T1("1.0.0-alfa.1"), T2("1.0.0-alfa.1"))
 	assert.Equal(t, 0, c)
 	assert.NoError(t, err)
-	c, err = f("1.0.0", "1.0.0-alfa.1")
+	c, err = f(T1("1.0.0"), T2("1.0.0-alfa.1"))
 	assert.Equal(t, 1, c)
 	assert.NoError(t, err)
-	c, err = f("1.0.0-alfa.1", "1.0.0")
+	c, err = f(T1("1.0.0-alfa.1"), T2("1.0.0"))
 	assert.Equal(t, -1, c)
 	assert.NoError(t, err)
-	c, err = f("1.0.0-alfa.2", "1.0.0-alfa.1")
+	c, err = f(T1("1.0.0-alfa.2"), T2("1.0.0-alfa.1"))
 	assert.Equal(t, 1, c)
 	assert.NoError(t, err)
-	c, err = f("1.0.0-alfa.1", "1.0.0-alfa.2")
+	c, err = f(T1("1.0.0-alfa.1"), T2("1.0.0-alfa.2"))
 	assert.Equal(t, -1, c)
 	assert.NoError(t, err)
-	c, err = f("1.0", "0.0.0")
+	c, err = f(T1("1.0"), T2("0.0.0"))
 	assert.Empty(t, c)
 	assert.Error(t, err)
-	c, err = f("0.0.0", "1.0")
+	c, err = f(T1("0.0.0"), T2("1.0"))
 	assert.Empty(t, c)
 	assert.Error(t, err)
 }
 
 func Test_CompareTag(t *testing.T) {
-	testCompareTag(t, CompareTag)
+	testCompareTag[string, string](t, CompareTag[string, string])
 }
 
-func testCompareTag(t *testing.T, f func(string, string) (int, error)) {
+func testCompareTag[T1, T2 constraint.ParserInput](t *testing.T, f func(T1, T2) (int, error)) {
 	t.Helper()
-	c, err := f("v0.0.0", "v0.0.0")
+	c, err := f(T1("v0.0.0"), T2("v0.0.0"))
 	assert.Equal(t, 0, c)
 	assert.NoError(t, err)
-	c, err = f("v1.0.0", "v0.0.0")
+	c, err = f(T1("v1.0.0"), T2("v0.0.0"))
 	assert.Equal(t, 1, c)
 	assert.NoError(t, err)
-	c, err = f("v0.0.0", "v1.0.0")
+	c, err = f(T1("v0.0.0"), T2("v1.0.0"))
 	assert.Equal(t, -1, c)
 	assert.NoError(t, err)
-	c, err = f("v1.0", "v0.0.0")
+	c, err = f(T1("v1.0"), T2("v0.0.0"))
 	assert.Empty(t, c)
 	assert.Error(t, err)
-	c, err = f("v0.0.0", "v1.0")
+	c, err = f(T1("v0.0.0"), T2("v1.0"))
 	assert.Empty(t, c)
 	assert.Error(t, err)
 }
 
 func Test_Compare(t *testing.T) {
-	testCompareVersion(t, Compare)
-	testCompareTag(t, Compare)
+	testCompareVersion[string, string](t, Compare[string, string])
+	testCompareTag[string, string](t, Compare[string, string])
 }

--- a/sem/errors.go
+++ b/sem/errors.go
@@ -7,6 +7,8 @@ package sem
 import (
 	"errors"
 	"fmt"
+
+	"go.lstv.dev/util/constraint"
 )
 
 var (
@@ -43,14 +45,14 @@ var (
 
 // ParseError represents error during version parsing.
 // Input can be empty, as same as Err.
-type ParseError struct {
+type ParseError[T constraint.ParserInput] struct {
 	Func  string
-	Input string
+	Input T
 	Err   error
 }
 
-func newParseError(funcName, input string, err error) *ParseError {
-	return &ParseError{
+func newParseError[T constraint.ParserInput](funcName string, input T, err error) *ParseError[T] {
+	return &ParseError[T]{
 		Func:  funcName,
 		Input: input,
 		Err:   err,
@@ -58,17 +60,17 @@ func newParseError(funcName, input string, err error) *ParseError {
 }
 
 // Unwrap returns under-laying error if any.
-func (e *ParseError) Unwrap() error {
+func (e *ParseError[T]) Unwrap() error {
 	return e.Err
 }
 
 // Error returns string representation of error.
-func (e *ParseError) Error() string {
+func (e *ParseError[T]) Error() string {
 	err := "invalid version"
 	if e.Err != nil {
 		err = e.Err.Error()
 	}
-	if e.Input == "" {
+	if len(e.Input) == 0 {
 		return fmt.Sprintf("sem.%s: %s", e.Func, err)
 	}
 	return fmt.Sprintf("sem.%s: %q: %s", e.Func, e.Input, err)

--- a/sem/errors_test.go
+++ b/sem/errors_test.go
@@ -13,7 +13,7 @@ import (
 
 func Test_newParseError(t *testing.T) {
 	err := errors.New("parse error")
-	assert.Equal(t, &ParseError{
+	assert.Equal(t, &ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   err,
@@ -22,7 +22,7 @@ func Test_newParseError(t *testing.T) {
 
 func Test_ParseError_Unwrap(t *testing.T) {
 	err := errors.New("parse error")
-	assert.Equal(t, err, (&ParseError{
+	assert.Equal(t, err, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   err,
@@ -31,22 +31,22 @@ func Test_ParseError_Unwrap(t *testing.T) {
 
 func Test_ParseError_Error(t *testing.T) {
 	err := errors.New("parse error")
-	assert.Equal(t, `sem.UnmarshalJSON: invalid version`, (&ParseError{
+	assert.Equal(t, `sem.UnmarshalJSON: invalid version`, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "",
 		Err:   nil,
 	}).Error())
-	assert.Equal(t, `sem.UnmarshalJSON: parse error`, (&ParseError{
+	assert.Equal(t, `sem.UnmarshalJSON: parse error`, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "",
 		Err:   err,
 	}).Error())
-	assert.Equal(t, `sem.UnmarshalJSON: "1h": invalid version`, (&ParseError{
+	assert.Equal(t, `sem.UnmarshalJSON: "1h": invalid version`, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   nil,
 	}).Error())
-	assert.Equal(t, `sem.UnmarshalJSON: "1h": parse error`, (&ParseError{
+	assert.Equal(t, `sem.UnmarshalJSON: "1h": parse error`, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   err,

--- a/sem/latest.go
+++ b/sem/latest.go
@@ -4,14 +4,18 @@
 
 package sem
 
+import (
+	"go.lstv.dev/util/constraint"
+)
+
 // LatestVersion returns the latest version from passed ones.
 // If a or b is not valid version, error is returned.
-func LatestVersion(a, b string) (Ver, error) {
-	av, err := ParseVersion([]byte(a))
+func LatestVersion[T1, T2 constraint.ParserInput](a T1, b T2) (Ver, error) {
+	av, err := ParseVersion(a)
 	if err != nil {
 		return Ver{}, err
 	}
-	bv, err := ParseVersion([]byte(b))
+	bv, err := ParseVersion(b)
 	if err != nil {
 		return Ver{}, err
 	}
@@ -20,12 +24,12 @@ func LatestVersion(a, b string) (Ver, error) {
 
 // LatestTag returns the latest tag from passed ones.
 // If a or b is not valid tag, error is returned.
-func LatestTag(a, b string) (Ver, error) {
-	av, err := ParseTag([]byte(a))
+func LatestTag[T1, T2 constraint.ParserInput](a T1, b T2) (Ver, error) {
+	av, err := ParseTag(a)
 	if err != nil {
 		return Ver{}, err
 	}
-	bv, err := ParseTag([]byte(b))
+	bv, err := ParseTag(b)
 	if err != nil {
 		return Ver{}, err
 	}
@@ -34,12 +38,12 @@ func LatestTag(a, b string) (Ver, error) {
 
 // Latest returns the latest version from passed ones.
 // If a or b is not valid version or tag, error is returned.
-func Latest(a, b string) (Ver, error) {
-	av, err := Parse([]byte(a))
+func Latest[T1, T2 constraint.ParserInput](a T1, b T2) (Ver, error) {
+	av, err := Parse(a)
 	if err != nil {
 		return Ver{}, err
 	}
-	bv, err := Parse([]byte(b))
+	bv, err := Parse(b)
 	if err != nil {
 		return Ver{}, err
 	}

--- a/sem/latest_test.go
+++ b/sem/latest_test.go
@@ -7,16 +7,18 @@ package sem
 import (
 	"testing"
 
+	"go.lstv.dev/util/constraint"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_LatestVersion(t *testing.T) {
-	testLatestVersion(t, LatestVersion)
+	testLatestVersion[string, string](t, LatestVersion[string, string])
 }
 
-func testLatestVersion(t *testing.T, f func(string, string) (Ver, error)) {
+func testLatestVersion[T1, T2 constraint.ParserInput](t *testing.T, f func(T1, T2) (Ver, error)) {
 	t.Helper()
-	l, err := f("0.0.0", "0.0.0")
+	l, err := f(T1("0.0.0"), T2("0.0.0"))
 	assert.Equal(t, Ver{
 		Major:      0,
 		Minor:      0,
@@ -25,7 +27,7 @@ func testLatestVersion(t *testing.T, f func(string, string) (Ver, error)) {
 		Build:      "",
 	}, l)
 	assert.NoError(t, err)
-	l, err = f("1.0.0", "0.0.0")
+	l, err = f(T1("1.0.0"), T2("0.0.0"))
 	assert.Equal(t, Ver{
 		Major:      1,
 		Minor:      0,
@@ -34,7 +36,7 @@ func testLatestVersion(t *testing.T, f func(string, string) (Ver, error)) {
 		Build:      "",
 	}, l)
 	assert.NoError(t, err)
-	l, err = f("0.0.0", "1.0.0")
+	l, err = f(T1("0.0.0"), T2("1.0.0"))
 	assert.Equal(t, Ver{
 		Major:      1,
 		Minor:      0,
@@ -43,24 +45,24 @@ func testLatestVersion(t *testing.T, f func(string, string) (Ver, error)) {
 		Build:      "",
 	}, l)
 	assert.NoError(t, err)
-	l, err = f("1.0", "0.0.0")
+	l, err = f(T1("1.0"), T2("0.0.0"))
 	assert.Empty(t, l)
 	assert.Error(t, err)
-	l, err = f("0.0.0", "1.0")
+	l, err = f(T1("0.0.0"), T2("1.0"))
 	assert.Empty(t, l)
 	assert.Error(t, err)
-	l, err = f("0.0", "1.0")
+	l, err = f(T1("0.0"), T2("1.0"))
 	assert.Empty(t, l)
 	assert.Error(t, err)
 }
 
 func Test_LatestTag(t *testing.T) {
-	testLatestTag(t, LatestTag)
+	testLatestTag[string, string](t, LatestTag[string, string])
 }
 
-func testLatestTag(t *testing.T, f func(string, string) (Ver, error)) {
+func testLatestTag[T1, T2 constraint.ParserInput](t *testing.T, f func(T1, T2) (Ver, error)) {
 	t.Helper()
-	l, err := f("v0.0.0", "v0.0.0")
+	l, err := f(T1("v0.0.0"), T2("v0.0.0"))
 	assert.Equal(t, Ver{
 		Major:      0,
 		Minor:      0,
@@ -69,7 +71,7 @@ func testLatestTag(t *testing.T, f func(string, string) (Ver, error)) {
 		Build:      "",
 	}, l)
 	assert.NoError(t, err)
-	l, err = f("v1.0.0", "v0.0.0")
+	l, err = f(T1("v1.0.0"), T2("v0.0.0"))
 	assert.Equal(t, Ver{
 		Major:      1,
 		Minor:      0,
@@ -78,7 +80,7 @@ func testLatestTag(t *testing.T, f func(string, string) (Ver, error)) {
 		Build:      "",
 	}, l)
 	assert.NoError(t, err)
-	l, err = f("v0.0.0", "v1.0.0")
+	l, err = f(T1("v0.0.0"), T2("v1.0.0"))
 	assert.Equal(t, Ver{
 		Major:      1,
 		Minor:      0,
@@ -87,18 +89,18 @@ func testLatestTag(t *testing.T, f func(string, string) (Ver, error)) {
 		Build:      "",
 	}, l)
 	assert.NoError(t, err)
-	l, err = f("v1.0", "v0.0.0")
+	l, err = f(T1("v1.0"), T2("v0.0.0"))
 	assert.Empty(t, l)
 	assert.Error(t, err)
-	l, err = f("v0.0.0", "v1.0")
+	l, err = f(T1("v0.0.0"), T2("v1.0"))
 	assert.Empty(t, l)
 	assert.Error(t, err)
-	l, err = f("v0.0", "v1.0")
+	l, err = f(T1("v0.0"), T2("v1.0"))
 	assert.Empty(t, l)
 	assert.Error(t, err)
 }
 
 func Test_Latest(t *testing.T) {
-	testLatestVersion(t, Latest)
-	testLatestTag(t, Latest)
+	testLatestVersion[string, string](t, Latest[string, string])
+	testLatestTag[string, string](t, Latest[string, string])
 }

--- a/sem/parse.go
+++ b/sem/parse.go
@@ -21,6 +21,8 @@ var (
 
 type (
 	// Rule allows configuring Parser behavior.
+	// Available rules are:
+	//   RuleDisableTag
 	Rule int
 )
 

--- a/sem/parse_test.go
+++ b/sem/parse_test.go
@@ -7,6 +7,8 @@ package sem
 import (
 	"testing"
 
+	"go.lstv.dev/util/constraint"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,10 +52,10 @@ func Test_DefaultParser(t *testing.T) {
 }
 
 func Test_ParseVersion(t *testing.T) {
-	testParseVersion(t, ParseVersion)
+	testParseVersion(t, ParseVersion[string])
 }
 
-func testParseVersion(t *testing.T, f func([]byte) (Ver, error)) {
+func testParseVersion[T constraint.ParserInput](t *testing.T, f func(T) (Ver, error)) {
 	t.Helper()
 	valid := map[string]Ver{
 		"0.0.0": {
@@ -92,22 +94,22 @@ func testParseVersion(t *testing.T, f func([]byte) (Ver, error)) {
 		"1.0.0.0",
 	}
 	for in, out := range valid {
-		v, err := f([]byte(in))
+		v, err := f(T(in))
 		assert.Equal(t, out, v)
 		assert.NoError(t, err)
 	}
 	for _, in := range invalid {
-		v, err := f([]byte(in))
+		v, err := f(T(in))
 		assert.Empty(t, v)
 		assert.Error(t, err)
 	}
 }
 
 func Test_ParseTag(t *testing.T) {
-	testParseTag(t, ParseTag)
+	testParseTag(t, ParseTag[string])
 }
 
-func testParseTag(t *testing.T, f func([]byte) (Ver, error)) {
+func testParseTag[T constraint.ParserInput](t *testing.T, f func(T) (Ver, error)) {
 	t.Helper()
 	valid := map[string]Ver{
 		"v0.0.0": {
@@ -129,20 +131,20 @@ func testParseTag(t *testing.T, f func([]byte) (Ver, error)) {
 		"x",
 	}
 	for in, out := range valid {
-		v, err := f([]byte(in))
+		v, err := f(T(in))
 		assert.Equal(t, out, v)
 		assert.NoError(t, err)
 	}
 	for _, in := range invalid {
-		v, err := f([]byte(in))
+		v, err := f(T(in))
 		assert.Empty(t, v)
 		assert.Error(t, err)
 	}
 }
 
 func Test_Parse(t *testing.T) {
-	testParseVersion(t, Parse)
-	testParseTag(t, Parse)
+	testParseVersion(t, Parse[string])
+	testParseTag(t, Parse[string])
 }
 
 func assertUnmarshalText(t *testing.T, expected Ver, input string, f form) {

--- a/sem/version.go
+++ b/sem/version.go
@@ -6,6 +6,10 @@
 // See also: https://semver.org/
 package sem
 
+import (
+	"math/bits"
+)
+
 // Ver represents version consist of major, minor, patch, pre-release and build components.
 // Values major, minor and patch are represented as uint64.
 // Pre-release and build are strings, and they are omitted in string form if empty.
@@ -93,6 +97,57 @@ func (v Ver) Valid() error {
 		return ErrInvalidBuild
 	}
 	return nil
+}
+
+// NextMajor returns new version with incremented major and zero minor and patch.
+// Returned version has empty PreRelease and Build components.
+// It panics if current major is equal to math.MaxUint64.
+func (v Ver) NextMajor() Ver {
+	newMajor, overflow := bits.Add64(v.Major, 1, 0)
+	if overflow != 0 {
+		panic("maximum major version exceeded")
+	}
+	return Ver{
+		Major:      newMajor,
+		Minor:      0,
+		Patch:      0,
+		PreRelease: "",
+		Build:      "",
+	}
+}
+
+// NextMinor returns new version with same major, incremented minor and zero patch.
+// Returned version has empty PreRelease and Build components.
+// It panics if current minor is equal to math.MaxUint64.
+func (v Ver) NextMinor() Ver {
+	newMinor, overflow := bits.Add64(v.Minor, 1, 0)
+	if overflow != 0 {
+		panic("maximum minor version exceeded")
+	}
+	return Ver{
+		Major:      v.Major,
+		Minor:      newMinor,
+		Patch:      0,
+		PreRelease: "",
+		Build:      "",
+	}
+}
+
+// NextPatch returns new version with same major, same minor and incremented patch.
+// Returned version has empty PreRelease and Build components.
+// It panics if current patch is equal to math.MaxUint64.
+func (v Ver) NextPatch() Ver {
+	newPatch, overflow := bits.Add64(v.Patch, 1, 0)
+	if overflow != 0 {
+		panic("maximum patch version exceeded")
+	}
+	return Ver{
+		Major:      v.Major,
+		Minor:      v.Minor,
+		Patch:      newPatch,
+		PreRelease: "",
+		Build:      "",
+	}
 }
 
 // MarshalText converts version to text with Formatter.

--- a/sem/version_test.go
+++ b/sem/version_test.go
@@ -6,6 +6,7 @@ package sem
 
 import (
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,7 +47,7 @@ func Test_New(t *testing.T) {
 	})
 }
 
-func Test_Version_Compare(t *testing.T) {
+func Test_Ver_Compare(t *testing.T) {
 	a := Ver{}
 	b := Ver{}
 	assert.Equal(t, 0, a.Compare(b))
@@ -194,7 +195,7 @@ func Test_Version_Compare(t *testing.T) {
 	assert.Equal(t, 1, b.Compare(a))
 }
 
-func Test_Version_Latest(t *testing.T) {
+func Test_Ver_Latest(t *testing.T) {
 	a := Ver{}
 	b := Ver{}
 	assert.Equal(t, a, a.Latest(b))
@@ -320,7 +321,7 @@ func Test_Version_Latest(t *testing.T) {
 	assert.Equal(t, b, a.Latest(b))
 }
 
-func Test_Version_Valid(t *testing.T) {
+func Test_Ver_Valid(t *testing.T) {
 	v := Ver{}
 	assert.NoError(t, v.Valid())
 	v.PreRelease = "abcd"
@@ -341,7 +342,121 @@ func Test_Version_Valid(t *testing.T) {
 	assert.Error(t, v.Valid())
 }
 
-func Test_Version_MarshalText(t *testing.T) {
+func Test_Ver_NextMajor(t *testing.T) {
+	assert.Equal(t, Ver{
+		Major:      1,
+		Minor:      0,
+		Patch:      0,
+		PreRelease: "",
+		Build:      "",
+	}, Ver{
+		Major:      0,
+		Minor:      1,
+		Patch:      2,
+		PreRelease: "a",
+		Build:      "b",
+	}.NextMajor())
+	assert.Equal(t, Ver{
+		Major:      2,
+		Minor:      0,
+		Patch:      0,
+		PreRelease: "",
+		Build:      "",
+	}, Ver{
+		Major:      1,
+		Minor:      2,
+		Patch:      3,
+		PreRelease: "a",
+		Build:      "b",
+	}.NextMajor())
+	assert.Panics(t, func() {
+		Ver{
+			Major:      math.MaxUint64,
+			Minor:      2,
+			Patch:      3,
+			PreRelease: "a",
+			Build:      "b",
+		}.NextMajor()
+	})
+}
+
+func Test_Ver_NextMinor(t *testing.T) {
+	assert.Equal(t, Ver{
+		Major:      0,
+		Minor:      1,
+		Patch:      0,
+		PreRelease: "",
+		Build:      "",
+	}, Ver{
+		Major:      0,
+		Minor:      0,
+		Patch:      2,
+		PreRelease: "a",
+		Build:      "b",
+	}.NextMinor())
+	assert.Equal(t, Ver{
+		Major:      1,
+		Minor:      2,
+		Patch:      0,
+		PreRelease: "",
+		Build:      "",
+	}, Ver{
+		Major:      1,
+		Minor:      1,
+		Patch:      3,
+		PreRelease: "a",
+		Build:      "b",
+	}.NextMinor())
+	assert.Panics(t, func() {
+		Ver{
+			Major:      0,
+			Minor:      math.MaxUint64,
+			Patch:      3,
+			PreRelease: "a",
+			Build:      "b",
+		}.NextMinor()
+	})
+}
+
+func Test_Ver_NextPatch(t *testing.T) {
+	assert.Equal(t, Ver{
+		Major:      0,
+		Minor:      0,
+		Patch:      1,
+		PreRelease: "",
+		Build:      "",
+	}, Ver{
+		Major:      0,
+		Minor:      0,
+		Patch:      0,
+		PreRelease: "a",
+		Build:      "b",
+	}.NextPatch())
+	assert.Equal(t, Ver{
+		Major:      1,
+		Minor:      2,
+		Patch:      3,
+		PreRelease: "",
+		Build:      "",
+	}, Ver{
+		Major:      1,
+		Minor:      2,
+		Patch:      2,
+		PreRelease: "a",
+		Build:      "b",
+	}.NextPatch())
+	assert.Panics(t, func() {
+		Ver{
+			Major:      0,
+			Minor:      0,
+			Patch:      math.MaxUint64,
+			PreRelease: "a",
+			Build:      "b",
+		}.NextPatch()
+	})
+}
+
+func Test_Ver_MarshalText(t *testing.T) {
 	Formatter = func(buf []byte, v Ver, f Format) ([]byte, error) {
 		assert.Nil(t, buf)
 		assert.Equal(t, Ver{
@@ -387,7 +502,7 @@ func Test_Version_MarshalText(t *testing.T) {
 	assert.Equal(t, formatError, err)
 }
 
-func Test_Version_UnmarshalText(t *testing.T) {
+func Test_Ver_UnmarshalText(t *testing.T) {
 	Parser = func(input []byte, r Rule) (v Ver, err error) {
 		assert.Equal(t, []byte(`ab`), input)
 		assert.Equal(t, Rule(0), r)
@@ -424,7 +539,7 @@ func Test_Version_UnmarshalText(t *testing.T) {
 	}, v)
 }
 
-func Test_Version_StringTag(t *testing.T) {
+func Test_Ver_StringTag(t *testing.T) {
 	Formatter = func(buf []byte, v Ver, f Format) ([]byte, error) {
 		assert.Nil(t, buf)
 		assert.Equal(t, Ver{
@@ -461,7 +576,7 @@ func Test_Version_StringTag(t *testing.T) {
 	assert.Equal(t, `v1.2.3-a+b`, v.StringTag())
 }
 
-func Test_Version_String(t *testing.T) {
+func Test_Ver_String(t *testing.T) {
 	Formatter = func(buf []byte, v Ver, f Format) ([]byte, error) {
 		assert.Nil(t, buf)
 		assert.Equal(t, Ver{

--- a/size/errors.go
+++ b/size/errors.go
@@ -103,14 +103,14 @@ func (e *InvalidValueError[N]) Error() string {
 
 // ParseError represents error during version parsing.
 // Input can be empty, as same as Err.
-type ParseError struct {
+type ParseError[T constraint.ParserInput] struct {
 	Func  string
-	Input string
+	Input T
 	Err   error
 }
 
-func newParseError(funcName, input string, err error) *ParseError {
-	return &ParseError{
+func newParseError[T constraint.ParserInput](funcName string, input T, err error) *ParseError[T] {
+	return &ParseError[T]{
 		Func:  funcName,
 		Input: input,
 		Err:   err,
@@ -118,17 +118,17 @@ func newParseError(funcName, input string, err error) *ParseError {
 }
 
 // Unwrap returns under-laying error if any.
-func (e *ParseError) Unwrap() error {
+func (e *ParseError[T]) Unwrap() error {
 	return e.Err
 }
 
 // Error returns string representation of error.
-func (e *ParseError) Error() string {
+func (e *ParseError[T]) Error() string {
 	err := "unable to parse"
 	if e.Err != nil {
 		err = e.Err.Error()
 	}
-	if e.Input == "" {
+	if len(e.Input) == 0 {
 		return fmt.Sprintf("size.%s: %s", e.Func, err)
 	}
 	return fmt.Sprintf("size.%s: parsing %q: %s", e.Func, e.Input, err)

--- a/size/errors.go
+++ b/size/errors.go
@@ -7,6 +7,8 @@ package size
 import (
 	"errors"
 	"fmt"
+
+	"go.lstv.dev/util/constraint"
 )
 
 var (
@@ -79,24 +81,24 @@ func (e *InvalidUnitError) Error() string {
 }
 
 // InvalidValueError represents invalid combination of value and unit.
-type InvalidValueError struct {
-	Value uint64
+type InvalidValueError[N constraint.Numbers] struct {
+	Value N
 	Unit  string
 }
 
-func newInvalidValueError(value uint64, unit string) *InvalidValueError {
-	return &InvalidValueError{
+func newInvalidValueError[N constraint.Numbers](value N, unit string) *InvalidValueError[N] {
+	return &InvalidValueError[N]{
 		Value: value,
 		Unit:  unit,
 	}
 }
 
 // Error returns string representation of error.
-func (e *InvalidValueError) Error() string {
+func (e *InvalidValueError[N]) Error() string {
 	if e.Unit == "" {
-		return fmt.Sprintf("value %d without unit is not suitable for uint64", e.Value)
+		return fmt.Sprintf("value %v without unit is not suitable for uint64", e.Value)
 	}
-	return fmt.Sprintf("value %d with unit %q is not suitable for uint64", e.Value, e.Unit)
+	return fmt.Sprintf("value %v with unit %q is not suitable for uint64", e.Value, e.Unit)
 }
 
 // ParseError represents error during version parsing.

--- a/size/errors_test.go
+++ b/size/errors_test.go
@@ -24,18 +24,18 @@ func Test_InvalidUnitError_Error(t *testing.T) {
 }
 
 func Test_newInvalidValueError(t *testing.T) {
-	assert.Equal(t, &InvalidValueError{
+	assert.Equal(t, &InvalidValueError[uint64]{
 		Value: 1,
 		Unit:  Zebibyte,
-	}, newInvalidValueError(1, Zebibyte))
+	}, newInvalidValueError(uint64(1), Zebibyte))
 }
 
 func Test_InvalidValueError_Error(t *testing.T) {
-	assert.Equal(t, `value 1 without unit is not suitable for uint64`, (&InvalidValueError{
+	assert.Equal(t, `value 1 without unit is not suitable for uint64`, (&InvalidValueError[uint64]{
 		Value: 1,
 		Unit:  "",
 	}).Error())
-	assert.Equal(t, `value 1 with unit "ZiB" is not suitable for uint64`, (&InvalidValueError{
+	assert.Equal(t, `value 1 with unit "ZiB" is not suitable for uint64`, (&InvalidValueError[uint64]{
 		Value: 1,
 		Unit:  Zebibyte,
 	}).Error())

--- a/size/errors_test.go
+++ b/size/errors_test.go
@@ -43,7 +43,7 @@ func Test_InvalidValueError_Error(t *testing.T) {
 
 func Test_newParseError(t *testing.T) {
 	err := errors.New("parse error")
-	assert.Equal(t, &ParseError{
+	assert.Equal(t, &ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   err,
@@ -52,7 +52,7 @@ func Test_newParseError(t *testing.T) {
 
 func Test_ParseError_Unwrap(t *testing.T) {
 	err := errors.New("parse error")
-	assert.Equal(t, err, (&ParseError{
+	assert.Equal(t, err, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   err,
@@ -61,22 +61,22 @@ func Test_ParseError_Unwrap(t *testing.T) {
 
 func Test_ParseError_Error(t *testing.T) {
 	err := errors.New("parse error")
-	assert.Equal(t, `size.UnmarshalJSON: unable to parse`, (&ParseError{
+	assert.Equal(t, `size.UnmarshalJSON: unable to parse`, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "",
 		Err:   nil,
 	}).Error())
-	assert.Equal(t, `size.UnmarshalJSON: parse error`, (&ParseError{
+	assert.Equal(t, `size.UnmarshalJSON: parse error`, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "",
 		Err:   err,
 	}).Error())
-	assert.Equal(t, `size.UnmarshalJSON: parsing "1h": unable to parse`, (&ParseError{
+	assert.Equal(t, `size.UnmarshalJSON: parsing "1h": unable to parse`, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   nil,
 	}).Error())
-	assert.Equal(t, `size.UnmarshalJSON: parsing "1h": parse error`, (&ParseError{
+	assert.Equal(t, `size.UnmarshalJSON: parsing "1h": parse error`, (&ParseError[string]{
 		Func:  "UnmarshalJSON",
 		Input: "1h",
 		Err:   err,

--- a/size/parse.go
+++ b/size/parse.go
@@ -37,6 +37,11 @@ var (
 
 type (
 	// Rule allows configuring Parser behavior.
+	// Available rules are:
+	//   RuleDisableUnit
+	//   RuleEnableJSONStringForm
+	//   RuleEnableJSONObjectForm
+	//   RuleDisallowUnknownKeys
 	Rule int
 )
 

--- a/size/parse_test.go
+++ b/size/parse_test.go
@@ -197,10 +197,10 @@ var (
 )
 
 type decoderMock struct {
-	queue []interface{} // json.Token or error
+	queue []any // json.Token or error
 }
 
-func newDecoderMock(tokensOrErrors ...interface{}) *decoderMock {
+func newDecoderMock(tokensOrErrors ...any) *decoderMock {
 	return &decoderMock{
 		queue: tokensOrErrors,
 	}

--- a/size/parse_test.go
+++ b/size/parse_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"go.lstv.dev/util/constraint"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,24 +48,24 @@ func Test_DefaultParser(t *testing.T) {
 	assertDefaultParser(t, 1000, "1 kB", 0)
 	assertDefaultParserError(t, `size.DefaultParser: parsing "1048576 EiB": value 1048576 with unit "EiB" is not suitable for uint64`, "1048576 EiB", 0)
 
-	testUnmarshalJSON(t, DefaultParser)
+	testUnmarshalJSON[string](t, DefaultParser[string])
 }
 
-func assertUnmarshalJSON(t *testing.T, f func(input []byte, r Rule) (Size, error), expected uint64, input string, r Rule) {
+func assertUnmarshalJSON[T constraint.ParserInput](t *testing.T, f func(input T, r Rule) (Size, error), expected uint64, input string, r Rule) {
 	t.Helper()
-	s, err := f([]byte(input), r)
+	s, err := f(T(input), r)
 	assert.NoErrorf(t, err, "invalid case for input %q", input)
 	assert.Equal(t, Size(expected), s, "invalid case for input %q: expected %d bytes", input, expected)
 }
 
-func assertUnmarshalJSONError(t *testing.T, f func(input []byte, r Rule) (Size, error), error, input string, r Rule) {
+func assertUnmarshalJSONError[T constraint.ParserInput](t *testing.T, f func(input T, r Rule) (Size, error), error, input string, r Rule) {
 	t.Helper()
-	s, err := f([]byte(input), r)
+	s, err := f(T(input), r)
 	assert.EqualErrorf(t, err, error, "invalid case for input %q", input)
 	assert.Zero(t, s, "invalid case for input %q: expected zero", input)
 }
 
-func testUnmarshalJSON(t *testing.T, f func(input []byte, r Rule) (Size, error)) {
+func testUnmarshalJSON[T constraint.ParserInput](t *testing.T, f func(input T, r Rule) (Size, error)) {
 	t.Helper()
 
 	rule := RuleEnableJSONStringForm | RuleEnableJSONObjectForm
@@ -89,7 +91,7 @@ func testUnmarshalJSON(t *testing.T, f func(input []byte, r Rule) (Size, error))
 }
 
 func Test_UnmarshalJSON(t *testing.T) {
-	testUnmarshalJSON(t, unmarshalJSON)
+	testUnmarshalJSON[[]byte](t, unmarshalJSON[[]byte])
 }
 
 type spacePermutation []rune


### PR DESCRIPTION
# Description
## [0.4.0] - 2022-03-16
### Added
- Package `constraint` with generic support and helpers.
- Function `size.Bytes` with generic support.
- Methods `sem.Ver.NextMajor`, `sem.Ver.NextMinor` and `sem.Ver.NextPatch`.

### Changed
- Type `Rule` doc comments (all packages).
- Used `any` instead of `interface{}`.
- Generic support:
  - Error types.
  - Function `size.New`
  - All parser functions now accepts `constraint.ParserInput`.
- Updated:
  - Go to 1.18
  - `github.com/stretchr/testify` to `1.7.1`

### Removed
- Methods of `size.Size`:
  - `BytesInt`
  - `BytesUint`
  - `BytesInt32`
  - `BytesUint32`
  - `BytesInt64`
  - `BytesUint64`
  - `BytesFloat32`
  - `BytesFloat64`

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Documentation update.

# How Has This Been Tested?

- [x] `go test`
- [x] `go vet`

**Run Configuration**:
- `util` package version: `0.3.0`
- Go version: `go1.18`
- Operating system: `darwin`
- Processor architecture: `amd64`

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] My change is documented in `CHANGELOG.md`.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (`README.md`, `openapi.yaml`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

@schenkova @bafrnec
