### PR TITLE
fix(test): allow to test pointer types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.7.1] - 2022-04-27
+### Fixed
+- Package `test` allows to test also pointer types.
+
 ## [0.7.0] - 2022-04-25
 ### Added
 - Format/parse and `fmt.Formatter` support for `uu` package.
@@ -100,7 +104,8 @@
 ### Added
 - First release of util.
 
-[Unreleased]: https://github.com/livesport-tv/util/compare/v0.7.0...master
+[Unreleased]: https://github.com/livesport-tv/util/compare/v0.7.1...master
+[0.7.1]: https://github.com/livesport-tv/util/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/livesport-tv/util/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/livesport-tv/util/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/livesport-tv/util/compare/v0.4.0...v0.5.0


### PR DESCRIPTION
# Description

## [0.7.1] - 2022-04-27
### Fixed
- Package `test` allows to test also pointer types.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# How Has This Been Tested?

- [x] `go test`
- [x] `go vet`

**Run Configuration**:
- `util` package version: `0.7.0`
- Go version: `go1.18.1`
- Operating system: `darwin`
- Processor architecture: `amd64`

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] My change is documented in `CHANGELOG.md`.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

@schenkova @bafrnec
